### PR TITLE
Add documentation and extend the XAS modes

### DIFF
--- a/applications/NXxas_new.nxdl.xml
+++ b/applications/NXxas_new.nxdl.xml
@@ -53,7 +53,6 @@
         </group>
         <group type="NXedge" name="edge">
             <doc>Absorption edge</doc>
-
         </group>
         <field name="calculated" type="NX_BOOLEAN" units="NX_UNITLESS" optional="true">
             <doc>Specify if the data commes from a calculation</doc>

--- a/base_classes/NXxas_mode.nxdl.xml
+++ b/base_classes/NXxas_mode.nxdl.xml
@@ -27,59 +27,84 @@
   <doc>XAS measurement mode</doc>
   <field name="name" type="NX_CHAR" minOccurs="1" maxOccurs="1">
     <doc>
-        X-ray absorption spectroscopy (XAS) is a techinque that measures the absorption coefficient :math:`\mu(E)` of a material as a function of energy.
+      X-ray absorption spectroscopy (XAS) is a techinque that measures the absorption coefficient :math:`\mu(E)` of a material as a function of energy.
 
-        The name of the XAS mode indicates the type of process being monitored to obtain the spectrum. Below is a description of the available modes, with emphasis on the expected values for the `intensity` and `monitor` fields.
+      The name of the XAS mode indicates the type of process being monitored to obtain the spectrum. Below is a description of the available modes, with emphasis on the expected values for the `intensity` and `monitor` fields.
 
-        The absorption coefficient is obtained by measuring the intensity of the incident :math:`I_0` and transmitted beam :math:`I`.       
+      The absorption coefficient is obtained by measuring the intensity of the incident :math:`I_0` and transmitted beam :math:`I`.       
 
-        .. math::
-            \mu(E) = -\ln(I/I_0)
+      .. math::
+          \mu(E) = -\ln(I/I_0)
     </doc>
     <enumeration>
       <item value="transmission">
         <doc>
-                        TODO
+          Transmission
         </doc>
       </item>
-      <item value="fluorescence yield">
+      <item value="tfy">
         <doc>
-                        TODO total or partial fluorescence yield
+          Total Fluorescence Yield
+        </doc>
+      </item>
+      <item value="pfy">
+        <doc>
+          Partial Fluorescence Yield
+        </doc>
+      </item>
+      <item value="ipfy">
+        <doc>
+          Inverse Partial Fluorescence Yield
         </doc>
       </item>
       <item value="herfd">
         <doc>
-                        TODO high energy resolution fluorescence detected
+          High Energy Resolution Fluorescence Detected
         </doc>
       </item>
-      <item value="electron yield">
+      <item value="tey">
         <doc>
-                        TODO total or partial electron yield
+          Total Electron Yield
+        </doc>
+      </item>
+      <item value="pey">
+        <doc>
+          Partial Electron Yield
+        </doc>
+      </item>
+      <item value="eels">
+        <doc>
+          Electron Energy Loss
         </doc>
       </item>
       <item value="luminescence">
         <doc>
-                        TODO
+          Luminescence
         </doc>
       </item>
-      <item value="x-ray Raman">
+      <item value="raman">
         <doc>
-                        TODO
-        </doc>
-      </item>
-      <item value="electron energy loss">
-        <doc>
-                        TODO
+          X-ray Raman Scattering
         </doc>
       </item>
       <item value="dafs">
         <doc>
-                        TODO
+          Diffraction Anomalous Fine Structure
+        </doc>
+      </item>
+      <item value="xeol">
+        <doc>
+          X-ray Excited Optical Luminescence
+        </doc>
+      </item>
+      <item value="reflexafs">
+        <doc>
+          Grazing Angle Reflection Extended X-ray Absorption Fine Structure
         </doc>
       </item>
       <item value="other">
         <doc>
-                        TODO
+          Other
         </doc>
       </item>
     </enumeration>

--- a/base_classes/NXxas_mode.nxdl.xml
+++ b/base_classes/NXxas_mode.nxdl.xml
@@ -27,14 +27,45 @@
   <doc>XAS measurement mode</doc>
   <field name="name" type="NX_CHAR" minOccurs="1" maxOccurs="1">
     <doc>
-      X-ray absorption spectroscopy (XAS) is a techinque that measures the absorption coefficient :math:`\mu(E)` of a material as a function of energy.
+      X-ray absorption spectroscopy (XAS) is a technique that measures the absorption coefficient :math:`\mu(E)` of a material as a function of energy.
 
       The name of the XAS mode indicates the type of process being monitored to obtain the spectrum. Below is a description of the available modes, with emphasis on the expected values for the `intensity` and `monitor` fields.
 
-      The absorption coefficient is obtained by measuring the intensity of the incident :math:`I_0` and transmitted beam :math:`I`.       
+      1. Transmission
+
+      The absorption coefficient is obtained by measuring the intensity of the incident :math:`I_0` and transmitted beam :math:`I`.
 
       .. math::
           \mu(E) = -\ln(I/I_0)
+
+      2. Total fluorescence yield (TFY)
+
+      The absorption coefficient is obtained by measuring the intensity of the emitted fluorescence :math:`I_f` and the incident beam :math:`I_0`.
+
+      .. math::
+          \mu(E) \propto I_f/I_0
+
+      3. Partial fluorescence yield (PFY)
+
+      4. Inverse partial fluorescence yield (IPFY)
+
+      5. High-energy resolution fluorescence detection (HERFD)
+
+      6. Total electron yield (TEY)
+
+      7. Partial electron yield (PEY)
+
+      8. Electron energy loss (EELS)
+
+      9. X-ray Raman Scattering (XRS)
+
+      10. Diffraction Anomalous Fine Structure (DAFS)
+
+      11. X-ray Excited Optical Luminescence (XEOL)
+
+      12. Grazing Angle Reflection Extended X-ray Absorption Fine Structure (ReflEXAFS)
+
+      13. Other
     </doc>
     <enumeration>
       <item value="transmission">
@@ -75,11 +106,6 @@
       <item value="eels">
         <doc>
           Electron Energy Loss
-        </doc>
-      </item>
-      <item value="luminescence">
-        <doc>
-          Luminescence
         </doc>
       </item>
       <item value="raman">

--- a/base_classes/NXxas_mode.nxdl.xml
+++ b/base_classes/NXxas_mode.nxdl.xml
@@ -27,7 +27,14 @@
   <doc>XAS measurement mode</doc>
   <field name="name" type="NX_CHAR" minOccurs="1" maxOccurs="1">
     <doc>
-        Name of the mode
+        X-ray absorption spectroscopy (XAS) is a techinque that measures the absorption coefficient :math:`\mu(E)` of a material as a function of energy.
+
+        The name of the XAS mode indicates the type of process being monitored to obtain the spectrum. Below is a description of the available modes, with emphasis on the expected values for the `intensity` and `monitor` fields.
+
+        The absorption coefficient is obtained by measuring the intensity of the incident :math:`I_0` and transmitted beam :math:`I`.       
+
+        .. math::
+            \mu(E) = -\ln(I/I_0)
     </doc>
     <enumeration>
       <item value="transmission">


### PR DESCRIPTION
The documentation built from the current merge request: https://hdf5.gitlab-pages.esrf.fr/nexus/nxxas/classes/applications/NXxas_new.html

An editable document for the working group can be found here https://docs.google.com/document/d/1M-9ViaEiaR6fUwb5IffQILodOSTvJq5s.

The contents of that document will be put in the doctring.